### PR TITLE
Remove PER_PAGE parameter from consts

### DIFF
--- a/data/consts.js
+++ b/data/consts.js
@@ -43,6 +43,5 @@ export const TAG_PHOTOGRAPHER = "photographer";
 export const SVG_WIDTH = 60;
 export const SVG_HEIGHT = 60;
 
-export const PER_PAGE = 25;
 export const LAST_YEAR = "2024";
 export const DEFAULT_EVENT = "Photo Tour";

--- a/dataACPC/consts.js
+++ b/dataACPC/consts.js
@@ -20,6 +20,5 @@ export const TAG_PHOTOGRAPHER = "photographer";
 export const SVG_WIDTH = 60;
 export const SVG_HEIGHT = 60;
 
-export const PER_PAGE = 25;
 export const LAST_YEAR = "2023";
 export const DEFAULT_EVENT = "Photo Tour";

--- a/dataAE/consts.js
+++ b/dataAE/consts.js
@@ -20,6 +20,5 @@ export const TAG_PHOTOGRAPHER = "photographer";
 export const SVG_WIDTH = 60;
 export const SVG_HEIGHT = 60;
 
-export const PER_PAGE = 25;
 export const LAST_YEAR = "2023";
 export const DEFAULT_EVENT = "Photo Tour";

--- a/dataAP/consts.js
+++ b/dataAP/consts.js
@@ -21,6 +21,5 @@ export const TAG_PHOTOGRAPHER = "photographer";
 export const SVG_WIDTH = 60;
 export const SVG_HEIGHT = 60;
 
-export const PER_PAGE = 25;
 export const LAST_YEAR = "2025";
 export const DEFAULT_EVENT = "Photo Tour";

--- a/dataAW/consts.js
+++ b/dataAW/consts.js
@@ -20,6 +20,5 @@ export const TAG_PHOTOGRAPHER = "photographer";
 export const SVG_WIDTH = 60;
 export const SVG_HEIGHT = 60;
 
-export const PER_PAGE = 25;
 export const LAST_YEAR = "2023";
 export const DEFAULT_EVENT = "Photo Tour";

--- a/dataEU/consts.js
+++ b/dataEU/consts.js
@@ -24,6 +24,5 @@ export const TAG_PHOTOGRAPHER = "photographer";
 export const SVG_WIDTH = 60;
 export const SVG_HEIGHT = 60;
 
-export const PER_PAGE = 25;
 export const LAST_YEAR = "2025";
 export const DEFAULT_EVENT = "Photo Tour";

--- a/dataLAC/consts.js
+++ b/dataLAC/consts.js
@@ -24,6 +24,5 @@ export const TAG_PHOTOGRAPHER = "photographer";
 export const SVG_WIDTH = 60;
 export const SVG_HEIGHT = 60;
 
-export const PER_PAGE = 25;
 export const LAST_YEAR = "2025";
 export const DEFAULT_EVENT = "Photo Tour";

--- a/dataNAC/consts.js
+++ b/dataNAC/consts.js
@@ -37,6 +37,5 @@ export const TAG_PHOTOGRAPHER = "photographer";
 export const SVG_WIDTH = 60;
 export const SVG_HEIGHT = 60;
 
-export const PER_PAGE = 25;
 export const LAST_YEAR = "2024";
 export const DEFAULT_EVENT = "Photo Tour";

--- a/src/Util/PhotoService.js
+++ b/src/Util/PhotoService.js
@@ -1,7 +1,6 @@
 import axios from "axios";
 
 import {
-  PER_PAGE,
   TAG_ALBUM,
   TAG_EVENT,
   TAG_TEAM,
@@ -27,7 +26,7 @@ function buildSearchUrl(tags = [], page = 1, text = "") {
     tag_mode: "all",
     page,
     sort: "date-taken-desc",
-    per_page: PER_PAGE,
+    per_page: 25,
     extras,
     format: "json",
     nojsoncallback: "?",

--- a/src/consts.js
+++ b/src/consts.js
@@ -32,7 +32,6 @@ export const TAG_PERSON = consts.TAG_PERSON;
 export const TAG_PHOTOGRAPHER = consts.TAG_PHOTOGRAPHER;
 export const SVG_WIDTH = consts.SVG_WIDTH;
 export const SVG_HEIGHT = consts.SVG_HEIGHT;
-export const PER_PAGE = consts.PER_PAGE;
 export const LAST_YEAR = consts.LAST_YEAR;
 export const DEFAULT_EVENT = consts.DEFAULT_EVENT;
 export const FLICKR_IMAGE_PREFIX = consts.FLICKR_IMAGE_PREFIX;


### PR DESCRIPTION
Remove the `PER_PAGE` constant from various files.

* Remove the `PER_PAGE` constant from `data/consts.js`, `dataACPC/consts.js`, `dataAE/consts.js`, `dataAP/consts.js`, `dataAW/consts.js`, `dataEU/consts.js`, `dataLAC/consts.js`, and `dataNAC/consts.js`.
* Remove the `PER_PAGE` constant from `src/consts.js`.
* Replace the `PER_PAGE` constant with a hardcoded value of 25 in the `buildSearchUrl` function in `src/Util/PhotoService.js`.

